### PR TITLE
fix: deduplicate street sampling by converting to undirected graph

### DIFF
--- a/api-trials/street_sampler.py
+++ b/api-trials/street_sampler.py
@@ -144,7 +144,8 @@ def _sample_edges(G, interval_m: float, edge_index: int,
     If *sample_all* is True, every edge in the graph is sampled.
     Otherwise only the edge at *edge_index* (sorted by length desc) is used.
     """
-    G_proj = ox.project_graph(G)
+    G_undir = ox.convert.to_undirected(G)
+    G_proj = ox.project_graph(G_undir)
     edges_proj = ox.graph_to_gdfs(G_proj, nodes=False)
     crs_metric = edges_proj.crs
 


### PR DESCRIPTION
OSMnx returns a directed graph with two edges per two-way street (u→v and v→u), causing the same physical road segment to be sampled twice with opposite bearings. Convert to undirected before sampling to eliminate duplicates.